### PR TITLE
Minor clarification of ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adguard for Android
 >
 ## Disclaimer
-Adguard for Android is not an open source project. We use GitHub as an open bug tracker for users to see what developers are working on.
+###Adguard for Android is not an open source project. We use GitHub as an open bug tracker for users to see what developers are working on.
 
 Adguard is the world's most advanced web filter and ad blocker for Android. It not only removes ads from browsers and applications on your smartphone/tablet, but also features such tools as firewall and phishing protection. Adguard gives you options of running it either in VPN or HTTP proxy mode, allowing to use it even without ROOT access. It immediately starts to filter all your traffic right after installation. 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Adguard for Android
-
-## >Disclaimer
->Adguard for Android is not an open source project. We use GitHub as an open bug tracker for users to see what developers are working on.
+>
+## Disclaimer
+Adguard for Android is not an open source project. We use GitHub as an open bug tracker for users to see what developers are working on.
 
 Adguard is the world's most advanced web filter and ad blocker for Android. It not only removes ads from browsers and applications on your smartphone/tablet, but also features such tools as firewall and phishing protection. Adguard gives you options of running it either in VPN or HTTP proxy mode, allowing to use it even without ROOT access. It immediately starts to filter all your traffic right after installation. 
 


### PR DESCRIPTION
@AdGuardTeam When quoting the ReadMe for https://github.com/AdguardTeam/AdguardForAndroid/issues/861#issuecomment-255901889, I happened to see the source, & realized, maybe, you all were attempting something more like this.  I happened to find a HTTP-link, too, though (I think) AdGuard.com went HTTPS-only some point within the last year.

What d'y'all think?